### PR TITLE
Added formatting functions

### DIFF
--- a/formatting/install.sh
+++ b/formatting/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+cp ./formatting/pre-commit ./.git/hooks/pre-commit
+chmod 755 ./.git/hooks/pre-commit
+
+for submodule in $(grep path .gitmodules | sed 's/.*= //') 
+do
+    cp formatting/pre-commit ./.git/modules/$submodule/hooks/pre-commit
+    chmod 755 ./.git/modules/$submodule/hooks/pre-commit
+done
+
+cp ./formatting/roboteam_clang-format.file /opt/roboteam_clang-format.file
+
+if hash clang-format 2>/dev/null; then 
+    echo "clang-format has been properly set up";
+else
+    echo "The files have been set up, however clang-format was not found"
+    echo "Install through:"
+    echo "  # apt install clang-format"
+    echo "  $ yay -S clang-format"
+    echo "  $ brew install clang-format"
+fi

--- a/formatting/install.sh
+++ b/formatting/install.sh
@@ -9,7 +9,7 @@ do
     chmod 755 ./.git/modules/$submodule/hooks/pre-commit
 done
 
-cp ./formatting/roboteam_clang-format.file /opt/roboteam_clang-format.file
+cp ./formatting/roboteam_clang-format.file ~/.config/roboteam_clang-format.file
 
 if hash clang-format 2>/dev/null; then 
     echo "clang-format has been properly set up";

--- a/formatting/pre-commit
+++ b/formatting/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+
+git diff --name-only | grep -E "\.(c|cpp|h|hpp)" --color=never | xargs clang-format -i -style="$(cat /opt/roboteam_clang-format.file)"

--- a/formatting/pre-commit
+++ b/formatting/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
 
-git diff --name-only | grep -E "\.(c|cpp|h|hpp)" --color=never | xargs clang-format -i -style="$(cat /opt/roboteam_clang-format.file)"
+git diff --name-only | grep -E "\.(c|cpp|h|hpp)" --color=never | xargs clang-format -i -style="$(cat ~/.config/roboteam_clang-format.file)"

--- a/formatting/roboteam_clang-format.file
+++ b/formatting/roboteam_clang-format.file
@@ -1,0 +1,1 @@
+{BasedOnStyle : Google, IndentWidth : 4, ColumnLimit : 180}


### PR DESCRIPTION
Install guide:

```bash
git clone git@github.com/roboteamtwente:roboteam_suite.git
cd roboteam_suite
git submodule update --init --recursive
sudo ./formatting/install.sh
```

Done.

Before you commit it will get all the filenames that you changed through
```
git diff --name-only
```

Then it greps the output

```bash
grep -E "\.(.c|cpp|h|hp)" --color=never
```
To make sure it only updates C++ and C files.
It then passes it to clang-format (credits to emiel)

```bash
xargs clang-format -i -style="$(cat /opt/roboteam_clang-format.file)"
```

As you can see, it reads the config from /opt/roboteam_clang-format.file, which is where install.sh puts it (the reason it needs sudo is to put it there)

:)