### PR TITLE
Add new tools to build Libusb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 include(cmake_modules/BuildSodium.cmake)
 include(cmake_modules/BuildZeroMQ.cmake)
+include(cmake_modules/BuildLibusb.cmake)
 
 # external libraries
 # stx

--- a/cmake_modules/BuildLibusb.cmake
+++ b/cmake_modules/BuildLibusb.cmake
@@ -1,0 +1,25 @@
+include(ExternalProject)
+set(libusb_src_dir   ${CMAKE_CURRENT_BINARY_DIR}/libusb/build)
+set(libusb_build_dir ${CMAKE_CURRENT_BINARY_DIR}/libusb)
+set(LIBUSB_LIB_DIR     ${libusb_build_dir}/lib)
+set(LIBUSB_INCLUDE_DIR ${libusb_build_dir}/include)
+find_package(udev)
+
+ExternalProject_Add(project_libusb
+        URL https://github.com/libusb/libusb/archive/refs/tags/v1.0.24.tar.gz
+        PREFIX     ${libusb_build_dir}
+        SOURCE_DIR ${libusb_src_dir}
+        BINARY_DIR ${libusb_src_dir}
+        CONFIGURE_COMMAND ${libusb_src_dir}/autogen.sh
+        BUILD_COMMAND ${libusb_src_dir}/configure --prefix=${libusb_build_dir} --with-libudev=${UDEV_LIBRARY}
+        INSTALL_COMMAND make -j3 install
+        BUILD_BYPRODUCTS ${LIBUSB_LIB_DIR}/libusb.a
+        )
+add_library(lib::usb STATIC IMPORTED)
+add_dependencies(lib::usb project_libusb)
+set_target_properties(lib::usb PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/libusb/lib/libusb-1.0.a)
+target_include_directories(lib::usb
+        INTERFACE ${LIBUSB_INCLUDE_DIR})
+target_link_libraries(lib::usb
+        INTERFACE ${UDEV_LIBRARY})
+file(MAKE_DIRECTORY ${LIBUSB_INCLUDE_DIR})

--- a/cmake_modules/Findudev.cmake
+++ b/cmake_modules/Findudev.cmake
@@ -1,0 +1,77 @@
+# - try to find the udev library
+#
+# Cache Variables: (probably not for direct use in your scripts)
+#  UDEV_INCLUDE_DIR
+#  UDEV_SOURCE_DIR
+#  UDEV_LIBRARY
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  UDEV_FOUND
+#  UDEV_INCLUDE_DIRS
+#  UDEV_LIBRARIES
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# Copyright 2014 Kevin M. Godby <kevin@godby.org>
+# SPDX-License-Identifier: BSL-1.0
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(UDEV_ROOT_DIR
+        "${UDEV_ROOT_DIR}"
+        CACHE
+        PATH
+        "Directory to search for udev")
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LIBUDEV libudev)
+endif()
+
+find_library(UDEV_LIBRARY
+        NAMES
+        udev
+        PATHS
+        ${PC_LIBUDEV_LIBRARY_DIRS}
+        ${PC_LIBUDEV_LIBDIR}
+        HINTS
+        "${UDEV_ROOT_DIR}"
+        PATH_SUFFIXES
+        lib
+        )
+
+get_filename_component(_libdir "${UDEV_LIBRARY}" PATH)
+
+find_path(UDEV_INCLUDE_DIR
+        NAMES
+        libudev.h
+        PATHS
+        ${PC_LIBUDEV_INCLUDE_DIRS}
+        ${PC_LIBUDEV_INCLUDEDIR}
+        HINTS
+        "${_libdir}"
+        "${_libdir}/.."
+        "${UDEV_ROOT_DIR}"
+        PATH_SUFFIXES
+        include
+        )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(udev
+        DEFAULT_MSG
+        UDEV_LIBRARY
+        UDEV_INCLUDE_DIR
+        )
+
+if(UDEV_FOUND)
+    list(APPEND UDEV_LIBRARIES ${UDEV_LIBRARY})
+    list(APPEND UDEV_INCLUDE_DIRS ${UDEV_INCLUDE_DIR})
+    mark_as_advanced(UDEV_ROOT_DIR)
+endif()
+
+mark_as_advanced(UDEV_INCLUDE_DIR
+        UDEV_LIBRARY)


### PR DESCRIPTION
This will ensure that libusb is built locally, instead of having to install libusb-1.0-0-dev