### PR TITLE
Use correct compiler arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,36 @@
 cmake_minimum_required(VERSION 3.16)
 project(rtt)
 
+# Build type compile flags
+set(CPP_STANDARD_FLAG "-std=c++20")
+set(DEBUG_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Wall" "-g" "-O0")
+set(RELEASE_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Ofast")
+
+# Specify manually which compiler arguments we want to use, either DEBUG or RELEASE ones
+# If you want to build in release mode, pass '-DCMAKE_BUILD_TYPE=RELEASE' as argument to cmake
+if (CMAKE_BUILD_TYPE MATCHES RELEASE)
+    message("Building in release mode")
+
+    set(COMPILER_FLAGS "${RELEASE_COMPILE_FLAGS}")
+else()
+    message("Building in debug mode")
+
+    # The default compiler flags are for debugging
+    set(COMPILER_FLAGS "${DEBUG_COMPILE_FLAGS}")
+endif()
+
+# Get the targets of the dependencies
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
+include(ccache) # For daster compiling
+include(LocateQt5) # For GUI and some networking
+include(FindSodium) # ? Not required...
+include(GetSDL) # For connecting joysticks to the GUI
+include(GetWebsocket) # ?
+include(GetZmqpp) # For networking between AI, RobotHub and World
+include(BuildLibusb) # USB library for RobotHub
 
-include(ccache)
-
-set(CMAKE_CXX_STANDARD 20) # -std=c++17
-set(CMAKE_CXX_STANDARD_REQUIRED ON) # -std=c++17 required
-set(CMAKE_POSITION_INDEPENDENT_CODE ON) # -fPic
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
-
-include(LocateQt5)
-include(FindSodium)
-include(GetSDL)
-include(GetWebsocket)
-include(GetZmqpp)
-include(BuildLibusb)
+# This will create a file in the build folder that contains the commands used for compiling
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # internal projects
 add_subdirectory(roboteam_networking)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,25 @@ include(GetSDL) # For connecting joysticks to the GUI
 include(GetWebsocket) # ?
 include(GetZmqpp) # For networking between AI, RobotHub and World
 include(BuildLibusb) # USB library for RobotHub
+include(CheckCXXCompilerFlag) # For testing compiler cxx standard support
+
+# Testing compiler cxx support
+check_cxx_compiler_flag(-std=c++20 COMPILER_SUPPORTS_CXX_20)
+check_cxx_compiler_flag(-std=c++2a COMPILER_SUPPORTS_CXX_2a)
+
+if (COMPILER_SUPPORTS_CXX_20)
+    set(CPP_STANDARD_FLAG "-std=c++20")
+elseif (COMPILER_SUPPORTS_2a)
+    set(CPP_STANDARD_FLAG "-std=c++2a")
+else ()
+    set(CPP_STANDARD_FLAG "")
+    # This CMake setting does not guarantee everything will be compiled with c++20 support, as
+    # these settings can be overwritten in targets by other libraries
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 # Build type compile flags
-set(CPP_STANDARD_FLAG "-std=c++20")
 set(DEBUG_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Wall" "-g" "-O0")
 set(RELEASE_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Ofast")
 
@@ -28,6 +44,8 @@ else()
     # The default compiler flags are for debugging
     set(COMPILER_FLAGS "${DEBUG_COMPILE_FLAGS}")
 endif()
+
+message("Compile flags: " "${COMPILER_FLAGS}")
 
 # This will create a file in the build folder that contains the commands used for compiling, useful for debugging
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CPP_STANDARD_FLAG "-std=c++20")
 set(DEBUG_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Wall" "-g" "-O0")
 set(RELEASE_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Ofast")
 
-# Specify manually which compiler arguments we want to use, either DEBUG or RELEASE ones
+# Specify manually which compiler arguments we want to use, either DEBUG (default) or RELEASE ones
 # If you want to build in release mode, pass '-DCMAKE_BUILD_TYPE=RELEASE' as argument to cmake
 if (CMAKE_BUILD_TYPE MATCHES RELEASE)
     message("Building in release mode")
@@ -29,7 +29,7 @@ include(GetWebsocket) # ?
 include(GetZmqpp) # For networking between AI, RobotHub and World
 include(BuildLibusb) # USB library for RobotHub
 
-# This will create a file in the build folder that contains the commands used for compiling
+# This will create a file in the build folder that contains the commands used for compiling, useful for debugging
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # internal projects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.16)
 project(rtt)
 
+# Get the targets of the dependencies
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
+include(ccache) # For daster compiling
+include(LocateQt5) # For GUI and some networking
+include(FindSodium) # ? Not required...
+include(GetSDL) # For connecting joysticks to the GUI
+include(GetWebsocket) # ?
+include(GetZmqpp) # For networking between AI, RobotHub and World
+include(BuildLibusb) # USB library for RobotHub
+
 # Build type compile flags
 set(CPP_STANDARD_FLAG "-std=c++20")
 set(DEBUG_COMPILE_FLAGS "${CPP_STANDARD_FLAG}" "-fPIC" "-Wall" "-g" "-O0")
@@ -18,16 +28,6 @@ else()
     # The default compiler flags are for debugging
     set(COMPILER_FLAGS "${DEBUG_COMPILE_FLAGS}")
 endif()
-
-# Get the targets of the dependencies
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
-include(ccache) # For daster compiling
-include(LocateQt5) # For GUI and some networking
-include(FindSodium) # ? Not required...
-include(GetSDL) # For connecting joysticks to the GUI
-include(GetWebsocket) # ?
-include(GetZmqpp) # For networking between AI, RobotHub and World
-include(BuildLibusb) # USB library for RobotHub
 
 # This will create a file in the build folder that contains the commands used for compiling, useful for debugging
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
This PR makes sure that all repositories are compiled with the same compiler arguments (like optimization, warning levels, etc). This allowed me to introduce the concept of DEBUG and RELEASE build types.
The RELEASE build type will produce the most optimized programs without displaying warnings during compiling
The DEBUG build type will produce programs that are not optimized, contain more information when errors happen, and will display more warnings when compiling.

What changes for you? By default, you will compile in debug mode (just like before, but now properly). If you specifically want to compile in release mode, you will have to pass a cmake argument: `-DCMAKE_BUILD_TYPE=RELEASE`. I would suggest if you want to switch often, to have a build/debug and a build/release folder to which you configure cmake once and then build the specific build type every time you need to.

This PR goes together with:
- roboteam_ai [fix/cleanCMake PR](https://github.com/RoboTeamTwente/roboteam_ai/pull/1330)
- roboteam_robothub [fix/cleanCMake PR](https://github.com/RoboTeamTwente/roboteam_robothub/pull/53)
- roboteam_utils [fix/cleanCMake PR](https://github.com/RoboTeamTwente/roboteam_utils/pull/109)
- roboteam_world [fix/cleanCMake PR](https://github.com/RoboTeamTwente/roboteam_world/pull/76)
- roboteam_networking [fix/cleanCMake PR](https://github.com/RoboTeamTwente/roboteam_networking/pull/6)