### PR TITLE
Update macOS support to reflect recent developments

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,20 +145,21 @@ $ sudo -s /bin/bash -c "git clone https://github.com/google/googletest.git /opt/
     make install"
 ```
 
-## Installation on macOS (tested on macOS 11.4 Big Sur)
+## Installation on macOS (tested on macOS 12.2.1 Monterey)
 Make sure you already have the following:
 - XCode
 - XCode Command Line Tools (Run XCode once, then `xcode-select --install`)
 - Homebrew
 
+
+Install remaining dependencies
 ```
-$ brew install cmake zmq armadillo libsodium qt@5 googletest
-$ brew install protobuf --HEAD     # As of 3.17.3, protobuf is is broken and neeeds to be compiled from HEAD
+$ brew install cmake zmq armadillo libsodium qt@5 protobuf llvm
 ```
 
-Create a sparse disk image with a case-sensitive FS to hold the source code
+Create a sparse (bundle) disk image with a case-sensitive FS to hold the source code
 ```
-$ hdiutil create -size 2g -volname rbtt-workspace -layout GPTSPUD -fs "Case-sensitive APFS" -type SPARSE -nospotlight ~/Desktop/rbtt-workspace
+$ hdiutil create -size 2g -volname rbtt-workspace -layout GPTSPUD -fs "Case-sensitive APFS" -type SPARSEBUNDLE -nospotlight ~/Desktop/rbtt-workspace
 $ hdiutil attach ~/Desktop/rbtt-workspace
 $ cd /Volumes/rbtt_workspace/
 $ git clone git@github.com:RoboTeamTwente/roboteam_suite.git
@@ -166,6 +167,19 @@ $ cd roboteam_suite/
 $ git submodule update --init --recursive
 $ git submodule foreach git checkout development
 ```
+
+Select a newer clang to be used to compile RBTT software
+
+1. Open CLion
+2. Go to Preferences -> Build, Execution, Deployment -> Toolchains -> Default
+3. Change C Compiler to:  `/usr/local/Cellar/llvm/13.0.1/bin/clang`
+4. Change C++ Compiler to: `/usr/local/Cellar/llvm/13.0.1/bin/clang++`
+
+Notes:
+* C(++) Compiler paths may differ based on installed version. Verify the version with `$ brew info llvm`
+* Toolchains may vary if you changed the default CLion settings. If you want to deviate from this readme, ensure the compiler selected in the toolchain used to compile RBTT software has support for C++20 
+
+
 
 ### Code Style Formatting
 To be consistent in the code style, we use clang-format. You can use clang-format to automatically format your code during every commit and you can use clang-format in CLion to format all code files in a given folder.

--- a/cmake_modules/BuildLibusb.cmake
+++ b/cmake_modules/BuildLibusb.cmake
@@ -1,25 +1,52 @@
 include(ExternalProject)
+
 set(libusb_src_dir   ${CMAKE_CURRENT_BINARY_DIR}/libusb/build)
 set(libusb_build_dir ${CMAKE_CURRENT_BINARY_DIR}/libusb)
 set(LIBUSB_LIB_DIR     ${libusb_build_dir}/lib)
 set(LIBUSB_INCLUDE_DIR ${libusb_build_dir}/include)
-find_package(udev)
 
-ExternalProject_Add(project_libusb
-        URL https://github.com/libusb/libusb/archive/refs/tags/v1.0.24.tar.gz
-        PREFIX     ${libusb_build_dir}
-        SOURCE_DIR ${libusb_src_dir}
-        BINARY_DIR ${libusb_src_dir}
-        CONFIGURE_COMMAND ${libusb_src_dir}/autogen.sh
-        BUILD_COMMAND ${libusb_src_dir}/configure --prefix=${libusb_build_dir} --with-libudev=${UDEV_LIBRARY}
-        INSTALL_COMMAND make -j3 install
-        BUILD_BYPRODUCTS ${LIBUSB_LIB_DIR}/libusb.a
-        )
+if (UNIX AND NOT APPLE)
+    find_package(udev)
+    ExternalProject_Add(project_libusb
+            URL https://github.com/libusb/libusb/archive/refs/tags/v1.0.24.tar.gz
+            PREFIX     ${libusb_build_dir}
+            SOURCE_DIR ${libusb_src_dir}
+            BINARY_DIR ${libusb_src_dir}
+            CONFIGURE_COMMAND ${libusb_src_dir}/autogen.sh
+            BUILD_COMMAND ${libusb_src_dir}/configure --prefix=${libusb_build_dir} --with-libudev=${UDEV_LIBRARY}
+            INSTALL_COMMAND make -j3 install
+            BUILD_BYPRODUCTS ${LIBUSB_LIB_DIR}/libusb-1.0.a
+            )
+else()
+    # No UDEV on macOS
+    ExternalProject_Add(project_libusb
+            URL https://github.com/libusb/libusb/archive/refs/tags/v1.0.24.tar.gz
+            PREFIX     ${libusb_build_dir}
+            SOURCE_DIR ${libusb_src_dir}
+            BINARY_DIR ${libusb_src_dir}
+            CONFIGURE_COMMAND ${libusb_src_dir}/autogen.sh
+            BUILD_COMMAND ${libusb_src_dir}/configure --prefix=${libusb_build_dir}
+            INSTALL_COMMAND make -j3 install
+            BUILD_BYPRODUCTS ${LIBUSB_LIB_DIR}/libusb-1.0.a
+            )
+endif()
+
 add_library(lib::usb STATIC IMPORTED)
 add_dependencies(lib::usb project_libusb)
+
 set_target_properties(lib::usb PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/libusb/lib/libusb-1.0.a)
+
 target_include_directories(lib::usb
         INTERFACE ${LIBUSB_INCLUDE_DIR})
-target_link_libraries(lib::usb
-        INTERFACE ${UDEV_LIBRARY})
+
+if (UNIX AND NOT APPLE)
+    target_link_libraries(lib::usb
+            INTERFACE ${UDEV_LIBRARY})
+elseif(APPLE)
+    find_library(CF CoreFoundation)
+    find_library(IK IOKit)
+    target_link_libraries(lib::usb INTERFACE ${CF} ${IK})
+endif()
+
+
 file(MAKE_DIRECTORY ${LIBUSB_INCLUDE_DIR})


### PR DESCRIPTION
- Default version of protobuf, qt5 (via homebrew) now work with automoc, remove special instructions
- sparsebundle is now the preferred disk image type, modify creation command in readme
- Udev is not available on macOS, but used in robothub (outside of sim). Don't link if compiled on macos
- C++20 is not supported by default on macOS, add newer llvm to dependencies, CLion instructions

Depends on https://github.com/RoboTeamTwente/roboteam_ai/pull/1334