### PR TITLE
Move settings of third party software

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,13 @@ project(rtt)
 # Get the targets of the dependencies
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules)
 include(ccache) # For daster compiling
-include(LocateQt5) # For GUI and some networking
 include(FindSodium) # ? Not required...
 include(GetSDL) # For connecting joysticks to the GUI
 include(GetWebsocket) # ?
 include(GetZmqpp) # For networking between AI, RobotHub and World
 include(BuildLibusb) # USB library for RobotHub
 include(CheckCXXCompilerFlag) # For testing compiler cxx standard support
+include(LocateQt5) # For GUI and some networking
 include(GetGoogleTest) # For testing
 
 # Recommended by official docs: https://google.github.io/googletest/quickstart-cmake.html

--- a/cmake_modules/GetGoogleTest.cmake
+++ b/cmake_modules/GetGoogleTest.cmake
@@ -7,3 +7,17 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(googletest)
+
+#for MacOS X or iOS, watchOS, tvOS(since 3.10.3)
+if (APPLE)
+    set(GTEST_LIB
+            /usr/local/lib/libgtest.a
+            /usr/local/lib/libgtest_main.a
+            /usr/local/lib/libgmock.a
+            /usr/local/lib/libgmock_main.a
+            )
+else (NOT APPLE)
+    set(GTEST_LIB
+            PUBLIC gtest
+            PUBLIC gmock)
+endif ()

--- a/cmake_modules/LocateQt5.cmake
+++ b/cmake_modules/LocateQt5.cmake
@@ -11,3 +11,17 @@ elseif(UNIX AND NOT APPLE)
 else()
     message(FATAL_ERROR "Can't auto-locate Qt5 for this platform")
 endif()
+
+# AUTOMOC is verified to work with the following:
+# - libprotoc 3.19.4
+# - macOS 12.2.1
+# - qt 5.15.2
+
+# On some operating systems, AUTOMOC might produce errors related to protobuf files.
+# In such a case, header files to be MOC-ed must be manually specified
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC OFF)
+set(CMAKE_AUTOUIC OFF)
+set(CMAKE_INCLUDE_CURRENT_DIR OFF) # Find includes in corresponding build directories
+
+find_package(Qt5 COMPONENTS Widgets Charts REQUIRED)


### PR DESCRIPTION
Previously, settings for GoogleTest and Qt were set in AI, which meant that other repositories did not have the guarantee that the settings still/already applied. Now, these settings are set on the moment we fetch these third party libraries